### PR TITLE
Add argument type and range for querying

### DIFF
--- a/docs/rest_api.md
+++ b/docs/rest_api.md
@@ -10,10 +10,10 @@ example:
 ```bash
 $ curl -X POST 'localhost:8080/groups/movie
   --data-raw '[
-    {"title": "Terminator", "text": "I'll be back"},
-    {"title": "StarWars", "text": "May the Force be with You"},
-    {"title": "DarkKnight", "text": "Why so Serious?", "actor": "Heath Ledger"},
-    {"title": "StarWars", "text": "I Am Your Father", "note": "Darth Vader"}
+    {"title": "Terminator", "text": "I'll be back", "year": 1984, "stars": 3.9},
+    {"title": "StarWars", "text": "May the Force be with You", "year": 1977, "stars": 3.9},
+    {"title": "DarkKnight", "text": "Why so Serious?", "actor": "Heath Ledger", "year": 2008, "stars": 4.3},
+    {"title": "StarWars", "subtitle": "The Empire Strikes Back", "text": "I Am Your Father", "year": 1980, "stars": 4.0}
   ]'
 ```
 ```
@@ -32,19 +32,148 @@ $ curl -X POST 'localhost:8080/groups/movie
 ### Find logs
 Find logs in a group which has a specific key-value:
 ```
-GET /groups/{group}?{key}={value}
+GET /groups/{group}?{query_cond1}&{query_cond2}&...
 ```
+{query_cond} for a specific value
+```
+{key}={value}       # string value
+{key}:int={value}   # int value   
+```
+{query_cond} for a range
+
+```
+{key}=[{value1}:{value2}]       # string in [value1, value2)
+{key}=[{value}:]                # string greater than or equal to value (≥ value)
+{key}=[:{value2}]               # string less than value (< value)
+
+{key}:int=[{value1}:{value2}]   # int in [value1, value2)   
+{key}:int=[{value}:]            # int greater than or equal to value (≥ value)   
+{key}:int=[:{value}]            # int less than value (< value)
+   
+{key}:float=[{value1}:{value2}] # float in [value1, value2)   
+{key}:float=[{value}:]          # int greater than or equal to value (≥ value)   
+{key}:float=[:{value}]          # int less than value (< value)
+```
+- Note that the upper and lower case letters are treated as different.
+In comparing strings, the character with lower Unicode value will be considered to be smaller,
+therefore the comparison results will be different from the dictionary order
+if the strings contain both upper and lower case letters. 
+It is recommended not to use both upper and lower case letters 
+in the string-typed fields which require range searching.
+
 example:
 ```bash
 $ curl -X GET 'localhost:8080/groups/movie?title=StarWars
 ```
 ```
 {
-  "logs": [
-    {"_id": "5e8b5903804f41da5370d844, "title": "StarWars", "text": "May the Force be with You"},
-    {"_id": "5e8b5903804f41da5370d846, "title": "StarWars", "text": "I Am Your Father", "note": "Darth Vader"}
+    "logs": [
+        {
+            "_id": "5e9325677efe79d511b112cc",
+            "title": "StarWars",
+            "text": "May the Force be with You",
+            "year": 1977,
+            "stars": 3.9
+        },
+        {
+            "_id": "5e9325677efe79d511b112ce",
+            "title": "StarWars",
+            "subtitle": "The Empire Strikes Back",
+            "text": "I Am Your Father",
+            "year": 1980,
+            "stars": 4
+        }
+    ]
 }
 ```
+```bash
+$ curl -X GET 'localhost:8080/groups/movie?text=[I'll:Why]
+```
+```
+{
+    "logs": [
+        {
+            "_id": "5e9325677efe79d511b112cb",
+            "title": "Terminator",
+            "text": "I'll be back",
+            "year": 1984,
+            "stars": 3.9
+        },
+        {
+            "_id": "5e9325677efe79d511b112cc",
+            "title": "StarWars",
+            "text": "May the Force be with You",
+            "year": 1977,
+            "stars": 3.9
+        }
+    ]
+}
+```
+```bash
+$ curl -X GET 'localhost:8080/groups/movie?year:int=1984
+```
+```
+{
+    "logs": [
+        {
+            "_id": "5e9325677efe79d511b112cb",
+            "title": "Terminator",
+            "text": "I'll be back",
+            "year": 1984,
+            "stars": 3.9
+        }
+    ]
+}
+```
+```bash
+$ curl -X GET 'localhost:8080/groups/movie?stars:float=[4.0:]
+```
+```
+{
+    "logs": [
+        {
+            "_id": "5e9325677efe79d511b112cd",
+            "title": "DarkKnight",
+            "text": "Why so Serious?",
+            "actor": "Heath Ledger",
+            "year": 2008,
+            "stars": 4.3
+        },
+        {
+            "_id": "5e9325677efe79d511b112ce",
+            "title": "StarWars",
+            "subtitle": "The Empire Strikes Back",
+            "text": "I Am Your Father",
+            "year": 1980,
+            "stars": 4
+        }
+    ]
+}
+```
+```bash
+$ curl -X GET 'localhost:8080/groups/movie?text=[I:J]&stars:float=[3.8:4.2]
+```
+```
+{
+    "logs": [
+        {
+            "_id": "5e9325677efe79d511b112cb",
+            "title": "Terminator",
+            "text": "I'll be back",
+            "year": 1984,
+            "stars": 3.9
+        },
+        {
+            "_id": "5e9325677efe79d511b112ce",
+            "title": "StarWars",
+            "subtitle": "The Empire Strikes Back",
+            "text": "I Am Your Father",
+            "year": 1980,
+            "stars": 4
+        }
+    ]
+}
+```
+
 * '_id' in response is determined automatically when inserted.
 * You can get all logs of a group without specifying key-value, but this is not recommended when the dataset is large. 
-* Only simple string key-value searching is supported currently. 

--- a/simplog/test/test_apiserver.py
+++ b/simplog/test/test_apiserver.py
@@ -14,10 +14,10 @@ class SimplogTestCase(unittest.TestCase):
         self.log_db = connection.logs
         movie_group_collection = self.log_db.movie
         self.movie_log_objects = [
-            dict(title='Terminator', text="I'll be back"),
-            dict(title='StarWars', message="May the Force be with You"),
-            dict(title='DarkKnight', message="Why so Serious?", actor="Heath Ledger", note="Joker"),
-            dict(title='StarWars', message="I Am Your Father", note="Darth Vader"),
+            dict(title='Terminator', text="I'll be back", year=1984, stars=3.9),
+            dict(title='StarWars', text="May the Force be with You", year=1977, stars=3.9),
+            dict(title='DarkKnight', text="Why so Serious?", actor="Heath Ledger", year=2008, stars=4.3),
+            dict(title='StarWars', subtitle="The Empire Strikes Back", text="I Am Your Father", year=1980, stars=4.0),
         ]
         for log_object in self.movie_log_objects:
             # inserted_id returns ObjectId,
@@ -74,6 +74,178 @@ class SimplogTestCase(unittest.TestCase):
         self.assertListEqual(
             result['logs'], expected_result,
             'GET /groups/movie?title=StarWars should return logs with title "StarWars"'
+        )
+
+    @inlineCallbacks
+    def test_GET_log_group_Test_response_data_Str_range_query(self):
+        # Given
+        # When
+        response = yield self.web.get(b'groups/movie', args={'text': '[I:J]'})
+        result = json.loads(response.written[0].decode('utf-8'))
+
+        # Then
+        expected_result = [
+            self.movie_log_objects[0],
+            self.movie_log_objects[3],
+        ]
+        self.assertListEqual(
+            result['logs'], expected_result,
+            'GET /groups/movie?text=[I:J] should return logs with text between I and J"'
+        )
+
+    @inlineCallbacks
+    def test_GET_log_group_Test_response_data_Str_range_query_Cond_left_open(self):
+        # Given
+        # When
+        response = yield self.web.get(b'groups/movie', args={'text': '[:W]'})
+        result = json.loads(response.written[0].decode('utf-8'))
+
+        # Then
+        expected_result = [
+            self.movie_log_objects[0],
+            self.movie_log_objects[1],
+            self.movie_log_objects[3],
+        ]
+        self.assertListEqual(
+            result['logs'], expected_result,
+            'GET /groups/movie?text=[:W] should return logs with text least than W'
+        )
+
+    @inlineCallbacks
+    def test_GET_log_group_Test_response_data_Str_range_query_Cond_right_open(self):
+        # Given
+        # When
+        response = yield self.web.get(b'groups/movie', args={'text': '[M:]'})
+        result = json.loads(response.written[0].decode('utf-8'))
+
+        # Then
+        expected_result = [
+            self.movie_log_objects[1],
+            self.movie_log_objects[2],
+        ]
+        self.assertListEqual(
+            result['logs'], expected_result,
+            'GET /groups/movie?text=[M:] should return logs with text greater than M"'
+        )
+
+    @inlineCallbacks
+    def test_GET_log_group_Test_response_data_Int_query(self):
+        # Given
+        # When
+        response = yield self.web.get(b'groups/movie', args={'year:int': '1984'})
+        result = json.loads(response.written[0].decode('utf-8'))
+
+        # Then
+        expected_result = [
+            self.movie_log_objects[0],
+        ]
+        self.assertListEqual(
+            result['logs'], expected_result,
+            'GET /groups/movie?year:int=1984 should return logs with year=1984'
+        )
+
+    @inlineCallbacks
+    def test_GET_log_group_Test_response_data_Int_range_query(self):
+        # Given
+        # When
+        response = yield self.web.get(b'groups/movie', args={'year:int': '[1980:2008]'})
+        result = json.loads(response.written[0].decode('utf-8'))
+
+        # Then
+        expected_result = [
+            self.movie_log_objects[0],
+            self.movie_log_objects[3],
+        ]
+        self.assertListEqual(
+            result['logs'], expected_result,
+            'GET /groups/movie?year:int=[1980:2008] should return logs with year in [1980,2008)'
+        )
+
+    @inlineCallbacks
+    def test_GET_log_group_Test_response_data_Int_range_query_Cond_left_open(self):
+        # Given
+        # When
+        response = yield self.web.get(b'groups/movie', args={'year:int': '[:1984]'})
+        result = json.loads(response.written[0].decode('utf-8'))
+
+        # Then
+        expected_result = [
+            self.movie_log_objects[1],
+            self.movie_log_objects[3],
+        ]
+        self.assertListEqual(
+            result['logs'], expected_result,
+            'GET /groups/movie?year:int=[:1984] should return logs with year in [,1984)'
+        )
+
+    @inlineCallbacks
+    def test_GET_log_group_Test_response_data_Int_range_query_Cond_right_open(self):
+        # Given
+        # When
+        response = yield self.web.get(b'groups/movie', args={'year:int': '[1980:]'})
+        result = json.loads(response.written[0].decode('utf-8'))
+
+        # Then
+        expected_result = [
+            self.movie_log_objects[0],
+            self.movie_log_objects[2],
+            self.movie_log_objects[3],
+        ]
+        self.assertListEqual(
+            result['logs'], expected_result,
+            'GET /groups/movie?year:int=[1980:] should return logs with year in [1980,)'
+        )
+
+    @inlineCallbacks
+    def test_GET_log_group_Test_response_data_Float_range_query(self):
+        # Given
+        # When
+        response = yield self.web.get(b'groups/movie', args={'stars:float': '[3.5:4.0]'})
+        result = json.loads(response.written[0].decode('utf-8'))
+
+        # Then
+        expected_result = [
+            self.movie_log_objects[0],
+            self.movie_log_objects[1],
+        ]
+        self.assertListEqual(
+            result['logs'], expected_result,
+            'GET /groups/movie?stars:float=[3.5:4.0] should return logs with stars=[3.5:4.0)'
+        )
+
+    @inlineCallbacks
+    def test_GET_log_group_Test_response_data_Float_range_query_Cond_left_open(self):
+        # Given
+        # When
+        response = yield self.web.get(b'groups/movie', args={'stars:float': '[:4.3]'})
+        result = json.loads(response.written[0].decode('utf-8'))
+
+        # Then
+        expected_result = [
+            self.movie_log_objects[0],
+            self.movie_log_objects[1],
+            self.movie_log_objects[3],
+        ]
+        self.assertListEqual(
+            result['logs'], expected_result,
+            'GET /groups/movie?stars:float=[:4.2] should return logs with stars=[:4.3)'
+        )
+
+    @inlineCallbacks
+    def test_GET_log_group_Test_response_data_Float_range_query_Cond_right_open(self):
+        # Given
+        # When
+        response = yield self.web.get(b'groups/movie', args={'stars:float': '[4.0:]'})
+        result = json.loads(response.written[0].decode('utf-8'))
+
+        # Then
+        expected_result = [
+            self.movie_log_objects[2],
+            self.movie_log_objects[3],
+        ]
+        self.assertListEqual(
+            result['logs'], expected_result,
+            'GET /groups/movie?stars:float=[4.0:] should return logs with stars=[4.0:)'
         )
 
     @inlineCallbacks


### PR DESCRIPTION
- Add argument type for querying
  - string (default, without type identifier)
  - int
  - float (for range querying)
```
{key}={value}         # string value
{key}:int={value}     # int value   
{key}:float={value}   # float value   
```
- Add range querying
```
{key}=[{value1}:{value2}]       # string in [value1, value2)
{key}=[{value}:]                # string greater than or equal to value (≥ value)
{key}=[:{value2}]               # string less than value (< value)

{key}:int=[{value1}:{value2}]   # int in [value1, value2)   
{key}:int=[{value}:]            # int greater than or equal to value (≥ value)   
{key}:int=[:{value}]            # int less than value (< value)
   
{key}:float=[{value1}:{value2}] # float in [value1, value2)   
{key}:float=[{value}:]          # int greater than or equal to value (≥ value)   
{key}:float=[:{value}]          # int less than value (< value)
```